### PR TITLE
Fix unlock showing server error when invalid token

### DIFF
--- a/app/spec/commands.spec.mjs
+++ b/app/spec/commands.spec.mjs
@@ -415,6 +415,17 @@ describe('unlock', () => {
     expect(res).toEqual(transactionFailedResponse());
     await User.deleteMany({});
   });
+
+  it('should fail if an invalid token is provided', async () => {
+    const res = await unlock({
+      data: { options: [
+        { name: 'token', value: 'FAKE' },
+      ] },
+      user: { id: '1234' }
+    });
+    expect(res).toEqual(tokenNotFoundResponse());
+    await User.deleteMany({});
+  });
 });
 
 describe('deposit', () => {

--- a/app/src/commands/unlock.js
+++ b/app/src/commands/unlock.js
@@ -1,6 +1,7 @@
 import {
   previewTransactionResponse,
   transactionFailedResponse,
+  tokenNotFoundResponse,
   embedResponse,
 } from '../responses/index.js';
 import { getOption } from './index.js';


### PR DESCRIPTION
- It wasn't tested
- The response type wasn't imported
